### PR TITLE
Change bbox fields from minx to xmin

### DIFF
--- a/src/queries/athena/0_create_external_table.sql
+++ b/src/queries/athena/0_create_external_table.sql
@@ -1,7 +1,7 @@
 CREATE EXTERNAL TABLE `__ATHENA_OVERTURE_RELEASE` (
   `id` string,
   `geometry` binary,
-  `bbox` struct<minx:double,maxx:double,miny:double,maxy:double>,
+  `bbox` struct<xmin:float,xmax:float,ymin:float,ymax:float>,
   `admin_level` int,
   `is_maritime` boolean,
   `geopol_display` string,

--- a/src/queries/athena/hyderabad_buildings.sql
+++ b/src/queries/athena/hyderabad_buildings.sql
@@ -9,7 +9,7 @@ SELECT
 FROM overture
 WHERE theme='buildings'
     AND type='building'
-    AND  bbox.minx > 78.4194
-    AND bbox.maxx < 78.5129
-    AND bbox.miny > 17.3427
-    AND bbox.maxy < 17.4192
+    AND  bbox.xmin > 78.4194
+    AND bbox.xmax < 78.5129
+    AND bbox.ymin > 17.3427
+    AND bbox.ymax < 17.4192

--- a/src/queries/athena/seattle_places.sql
+++ b/src/queries/athena/seattle_places.sql
@@ -8,7 +8,7 @@ FROM
     overture.release.__ATHENA_OVERTURE_RELEASE
 WHERE theme='places'
     AND type='place'
-    AND bbox.minX > -122.4447744
-        AND bbox.maxX < -122.2477071
-        AND bbox.minY > 47.5621587
-        AND bbox.maxY < 47.7120663
+    AND bbox.xmin > -122.4447744
+        AND bbox.xmax < -122.2477071
+        AND bbox.ymin > 47.5621587
+        AND bbox.ymax < 47.7120663

--- a/src/queries/duckdb/100_buildings.sql
+++ b/src/queries/duckdb/100_buildings.sql
@@ -12,8 +12,8 @@ SELECT
   ST_GeomFromWKB(geometry) as geometry
 FROM read_parquet('azure://release/2024-02-15-alpha.0/theme=buildings/type=*/*', filename=true, hive_partitioning=1)
 WHERE primary_name IS NOT NULL
-AND bbox.minX > -84.363175999999953
-AND bbox.maxX < -82.418395999999973
-AND bbox.minY > 41.706621000000041
-AND bbox.maxY < 43.327039000000070
+AND bbox.xmin > -84.363175999999953
+AND bbox.xmax < -82.418395999999973
+AND bbox.ymin > 41.706621000000041
+AND bbox.ymax < 43.327039000000070
 LIMIT 25;

--- a/src/queries/duckdb/buildings_detroit.sql
+++ b/src/queries/duckdb/buildings_detroit.sql
@@ -10,8 +10,8 @@ SELECT
   ST_GeomFromWKB(geometry) as geometry
 FROM read_parquet('azure://release/2024-02-15-alpha.0/theme=buildings/type=*/*', filename=true, hive_partitioning=1)
 WHERE primary_name IS NOT NULL 
-AND bbox.minX > -84.363175999999953
-AND bbox.maxX < -82.418395999999973
-AND bbox.minY > 41.706621000000041
-AND bbox.maxY < 43.327039000000070
+AND bbox.xmin > -84.363175999999953
+AND bbox.xmax < -82.418395999999973
+AND bbox.ymin > 41.706621000000041
+AND bbox.ymax < 43.327039000000070
 LIMIT 5;

--- a/src/queries/duckdb/confident_mountains.sql
+++ b/src/queries/duckdb/confident_mountains.sql
@@ -6,8 +6,8 @@ COPY(
     SELECT 
        id,
        names.primary as primary_name,
-       bbox.minx as x,
-       bbox.miny as y,
+       bbox.xmin as x,
+       bbox.ymin as y,
        ST_GeomFromWKB(geometry) as geometry,
        categories.main as main_category,
        sources[1].dataset AS primary_source,

--- a/src/queries/duckdb/hyderabad_buildings.sql
+++ b/src/queries/duckdb/hyderabad_buildings.sql
@@ -12,9 +12,9 @@ COPY (
         ST_GeomFromWkb(geometry) AS geometry
     FROM read_parquet('s3://overturemaps-us-west-2/release/2024-02-15-alpha.0/theme=buildings/type=*/*', filename=true, hive_partitioning=1)
     WHERE
-        bbox.minx > 78.4194
-        AND bbox.maxx < 78.5129
-        AND bbox.miny > 17.3427
-        AND bbox.maxy < 17.4192
+        bbox.xmin > 78.4194
+        AND bbox.xmax < 78.5129
+        AND bbox.ymin > 17.3427
+        AND bbox.ymax < 17.4192
 ) TO 'buildings_hyderabad.geojson'
 WITH (FORMAT GDAL, DRIVER 'GeoJSON', SRS 'EPSG:4326');

--- a/src/queries/duckdb/seattle_places.sql
+++ b/src/queries/duckdb/seattle_places.sql
@@ -20,9 +20,9 @@ COPY (
     FROM
        read_parquet('s3://overturemaps-us-west-2/release/__OVERTURE_RELEASE/theme=places/type=*/*', hive_partitioning=1)
     WHERE
-        bbox.minx > -122.4447744
-        AND bbox.maxx < -122.2477071
-        AND bbox.miny > 47.5621587
-        AND bbox.maxy < 47.7120663
+        bbox.xmin > -122.4447744
+        AND bbox.xmax < -122.2477071
+        AND bbox.xmin > 47.5621587
+        AND bbox.xmax < 47.7120663
     ) TO 'places_seattle.geojsonseq'
 WITH (FORMAT GDAL, DRIVER 'GeoJSONSeq', SRS 'EPSG:4326');

--- a/src/queries/synapse/seattle_places.sql
+++ b/src/queries/synapse/seattle_places.sql
@@ -16,7 +16,7 @@ WITH
     AS
         [result]
 WHERE
-        TRY_CONVERT(FLOAT, JSON_VALUE(bbox, '$.minx')) > -122.4447744
-    AND TRY_CONVERT(FLOAT, JSON_VALUE(bbox, '$.maxx')) < -122.2477071
-    AND TRY_CONVERT(FLOAT, JSON_VALUE(bbox, '$.miny')) > 47.5621587
-    AND TRY_CONVERT(FLOAT, JSON_VALUE(bbox, '$.maxy')) < 47.7120663
+        TRY_CONVERT(FLOAT, JSON_VALUE(bbox, '$.xmin')) > -122.4447744
+    AND TRY_CONVERT(FLOAT, JSON_VALUE(bbox, '$.xmax')) < -122.2477071
+    AND TRY_CONVERT(FLOAT, JSON_VALUE(bbox, '$.ymin')) > 47.5621587
+    AND TRY_CONVERT(FLOAT, JSON_VALUE(bbox, '$.ymax')) < 47.7120663


### PR DESCRIPTION
Overture data starting in 2024-04 release will comply with GeoParquet 1.1 bounding box field names. Update docs accordingly.

https://github.com/OvertureMaps/tf-data-platform/pull/119

minx -> xmin
miny -> ymin
maxx -> xmax
maxy -> ymax

bbox fields are also now float:
https://github.com/OvertureMaps/tf-data-platform/pull/202